### PR TITLE
php 8.2 throws deprecation warnings for dynamically created properties

### DIFF
--- a/Model/ChannelEngineApi.php
+++ b/Model/ChannelEngineApi.php
@@ -16,6 +16,10 @@ class ChannelEngineApi implements ChannelEngineApiInterface
      * @var SerializerInterface
      */
     private $_serializer;
+    /**
+     * @var QuoteIdMaskFactory $quoteIdMaskFactory
+     */
+    private $quoteIdMaskFactory;
 
     /**
      * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepo

--- a/Observer/StockItemObserver.php
+++ b/Observer/StockItemObserver.php
@@ -5,7 +5,12 @@ use Magento\Catalog\Model\ProductRepository;
 
 class StockItemObserver implements ObserverInterface
 {
-	public function __construct(ProductRepository $productRepository)
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    public function __construct(ProductRepository $productRepository)
 	{
 		$this->productRepository = $productRepository;
 	}

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -34,6 +34,18 @@ class UpgradeData implements UpgradeDataInterface
      * @var QuoteSetupFactory
      */
     private $quoteSetupFactory;
+    /**
+     * @var array|array[]
+     */
+    private $orderAttributes;
+    /**
+     * @var array|array[]
+     */
+    private $orderLineAttributes;
+    /**
+     * @var array|array[]
+     */
+    private $productAttributes;
 
     /**
     * @param ConfigBasedIntegrationManager $integrationManager


### PR DESCRIPTION
I was getting this error running the Magento 2.4.6 consumer
```
Deprecated Functionality: Creation of dynamic property ChannelEngine\Magento2\Model\ChannelEngineApi::$quoteIdMaskFactory is deprecated in /var/www/vendor/channelengine/magento2/Model/ChannelEngineApi.php on line 33
```
Found some more dynamic properties as well