### PR TITLE
Update BulkProductObserver.php

### DIFF
--- a/Observer/BulkProductObserver.php
+++ b/Observer/BulkProductObserver.php
@@ -72,8 +72,17 @@ class BulkProductObserver implements ObserverInterface
         if (!is_array($entities))
             return $ids;
 
-        foreach ($entities as $key => $value) {
-            $ids[] = $key;            
+        //Wrong code. This code returns the array key value and not the product ID. Causing the wrong products to be updated or if the product does not exist in catalog_product_entity, an error is produced in the 
+        //magento exeptions logs:
+        // Updating ce_updated_at field was unsuccessful {"exception":"[object] (Zend_Db_Statement_Exception(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`mydatabase`.`catalog_product_entity_datetime`, CONSTRAINT `CAT_PRD_ENTT_DTIME_ENTT_ID_CAT_PRD_ENTT_ENTT_ID` FOREIGN KEY (`entity_id`) REFERENCES
+        
+        //foreach ($entities as $key => $value) {
+        //    $ids[] = $key;            
+        //}
+
+        //New code
+        foreach ($entities as $product) {
+            $ids[] = $product->getId();
         }
 
         return $ids;


### PR DESCRIPTION
Unfortunately there is an issue with this code. In the BulkProductObserver.php on line 75 in the foreach statement, the value of the array key is returned not the product ID. 

This causes the wrong product to be updated or if the array key value does not match an entity_id in the catalog_product_enttity table then an error is thrown in the magento exception logs: 

 main.ERROR: Updating ce_updated_at field was unsuccessful {"exception":"[object] (Zend_Db_Statement_Exception(code: 23000): SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`mydatabase`.`catalog_product_entity_datetime`, CONSTRAINT `CAT_PRD_ENTT_DTIME_ENTT_ID_CAT_PRD_ENTT_ENTT_ID` FOREIGN KEY (`entity_id`) REFERENCES `catalog_product_entity` (`entity_id`) ON DELETE), query was: INSERT  INTO `catalog_product_entity_datetime` (`attribute_id`,`store_id`,`entity_id`,`value`) VALUES (?, ?, ?, '2025-01-16 15:37:34') ON DUPLICATE KEY UPDATE `attribute_id` = VALUES(`attribute_id`), `store_id` = VALUES(`store_id`), `entity_id` = VALUES(`entity_id`), `value` = VALUES(`value`) at /var/www/html/magento_instance/vendor/magento/framework/DB/Statement/Pdo/Mysql.php:109)

The code needs to be updated from:

   foreach ($entities as $key => $value) {
            $ids[] = $key;            
        }

To
foreach ($entities as $product) {
    $ids[] = $product->getId();
}
